### PR TITLE
feat: New issue templates for hl2 and portal

### DIFF
--- a/.github/ISSUE_TEMPLATE/hl2-bug.yml
+++ b/.github/ISSUE_TEMPLATE/hl2-bug.yml
@@ -1,7 +1,7 @@
-name: Portal 2 Bug Report
-description: Submit a bug report related to the Portal 2 campaign in P2CE
-title: "Portal 2 Bug: <Title>"
-labels: ["Type: bug", "Compat: Portal 2"]
+name: Half-Life 2 Bug Report
+description: Submit a bug report related to Half-Life 2 maps, entities or other features in P2CE
+title: "Half-Life 2 Bug: <Title>"
+labels: ["Type: bug", "Priority: Very Low", "Compat: Half-Life 2"]
 body:
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/portal-1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/portal-1-bug.yml
@@ -1,7 +1,7 @@
-name: Portal 2 Bug Report
-description: Submit a bug report related to the Portal 2 campaign in P2CE
-title: "Portal 2 Bug: <Title>"
-labels: ["Type: bug", "Compat: Portal 2"]
+name: Portal 1 Bug Report
+description: Submit a bug report related to Portal 1 maps, entities or other features in P2CE
+title: "Portal 1 Bug: <Title>"
+labels: ["Type: bug", "Compat: Portal 1"]
 body:
 - type: textarea
   attributes:


### PR DESCRIPTION
Automatically mark hl2 bugs as such (+ low priority), same for portal 1 bugs minus the priority flag.