### PR TITLE
Properly capitalize issue labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Submit a bug
 title: "Bug: <Title>"
-labels: ["Type: bug"]
+labels: ["Type: Bug"]
 body:
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a feature
 title: "Feature: <Title>"
-labels: ["Type: enhancement"]
+labels: ["Type: Enhancement"]
 body:
 - type: dropdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/hl2-bug.yml
+++ b/.github/ISSUE_TEMPLATE/hl2-bug.yml
@@ -1,7 +1,7 @@
-name: Half-Life 2 Bug Report
+name: Half-Life 2 Compat Bug Report
 description: Submit a bug report related to Half-Life 2 maps, entities or other features in P2CE
-title: "Half-Life 2 Bug: <Title>"
-labels: ["Type: bug", "Priority: Very Low", "Compat: Half-Life 2"]
+title: "Half-Life 2 Compat Bug: <Title>"
+labels: ["Type: Bug", "Priority: Very Low", "Compat: Half-Life 2"]
 body:
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/portal-1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/portal-1-bug.yml
@@ -1,7 +1,7 @@
-name: Portal 1 Bug Report
+name: Portal 1 Compat Bug Report
 description: Submit a bug report related to Portal 1 maps, entities or other features in P2CE
-title: "Portal 1 Bug: <Title>"
-labels: ["Type: bug", "Compat: Portal 1"]
+title: "Portal 1 Compat Bug: <Title>"
+labels: ["Type: Bug", "Compat: Portal 1"]
 body:
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/portal-2-bug.yml
+++ b/.github/ISSUE_TEMPLATE/portal-2-bug.yml
@@ -1,7 +1,7 @@
-name: Portal 2 Bug Report
+name: Portal 2 Compat Bug Report
 description: Submit a bug report related to the Portal 2 campaign in P2CE
-title: "Portal 2 Bug: <Title>"
-labels: ["Type: bug", "Compat: Portal 2"]
+title: "Portal 2 Compat Bug: <Title>"
+labels: ["Type: Bug", "Compat: Portal 2"]
 body:
 - type: textarea
   attributes:


### PR DESCRIPTION
I renamed some of the issue labels recently to fit the capitalization scheme used by the engine repo. Turned out that broke these templates! Here's a PR to fix 'em.